### PR TITLE
Use alpine linux base, add quota option and share name option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,14 @@ RUN apk add --update \
     bash \
     && rm -rf /var/cache/apk/*
 
-ADD samba.conf /etc/samba/smb.conf
+COPY samba.conf /etc/samba/smb.conf
 RUN /usr/bin/testparm -s
 
 EXPOSE 445/tcp
 ENV BACKUPDIR /backups
 
-ADD entrypoint /entrypoint
+COPY entrypoint /entrypoint
+COPY template_quota /tmp/
 RUN chmod 0755 /entrypoint
 
 ENTRYPOINT ["/entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM debian:sid
+FROM alpine:latest
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends --yes install \
-        samba \
-        samba-vfs-modules \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --update \
+    samba-common-tools \
+    samba-server \
+    shadow \
+    bash \
+    && rm -rf /var/cache/apk/*
 
 ADD samba.conf /etc/samba/smb.conf
 RUN /usr/bin/testparm -s

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ docker pull awlnx/samba-timemachine
 docker run -d -t \
     -v /backups/timemachine:/backups:z \
     -p 10445:445 \
-    --restart unless-stopped awlnx/samba-timemachine
+    --restart unless-stopped awlnx/samba-timemachine \
     --name timemachine
 ```
 
 Note that due to the use of port 10445 this container can be run along side a normal SAMBA service.
 
-There is a single user called `timemachine` with a random password generated at startup (you see it with `docker logs timemachine`). By default USERID and GROUPID are set to 2000 which maybe conflicts with your running system. 
+There is a single user called `timemachine` with a random password generated at startup (you see it with `docker logs timemachine`). By default USERID and GROUPID are set to 1311 which maybe conflicts with your running system. The default name of the share is "Data." 
 
-Set the environment variables USER, USERID, GROUPID AND/OR PASS to override.
+Set the environment variables USER, USERID, GROUPID, PASS,  AND/OR SHARENAME to override. A quota for each computer's backup can be set, in MB, with the TMSIZE environment variable.
 
 ```
 docker run -d -t  \
@@ -30,9 +30,11 @@ docker run -d -t  \
     -e PASS=test123 \
     -e USERID=1000 \
     -e GROUPID=1000 \
-    -v /backups:/backups:z
-    -p 10445:445 
-    --name timemachine
+    -e SHARENAME=myshare \
+    -e TMSIZE=1024000 \
+    -v /backups:/backups:z \
+    -p 10445:445 \
+    --name timemachine \
     --restart unless-stopped awlnx/samba-timemachine
 ```
 

--- a/entrypoint
+++ b/entrypoint
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 export PASS=${PASS:-RANDOM}
 export USER=${USER:-timemachine}
-export USERID=${USERID:-2000}
-export GROUPID=${GROUPID:-2000}
+export USERID=${USERID:-1311}
+export GROUPID=${GROUPID:-1311}
+export TMSIZE=${TMSIZE:-512000}
+export SHARENAME=${SHARENAME:-Data}
 
 createUser()
 {
@@ -25,13 +27,21 @@ backupConfig()
         exit 1
     else
 	echo "Granting permissions to ${USER}/${USERID} with  timemachine_users/${GROUPID} on ${BACKUPDIR}"
-        chown -R ${USER}:${ID} ${BACKUPDIR}
+        chown -R ${USER}:${GROUPID} ${BACKUPDIR}
     fi
+}
+
+makeOptions()
+{
+    TMSIZE=$(($TMSIZE * 1000000))
+    sed "s#REPLACE_TM_SIZE#${TMSIZE}#" /tmp/template_quota > ${BACKUPDIR}/.com.apple.TimeMachine.quota.plist
+    sed -i "s#REPLACE_SHARENAME#${SHARENAME}#" /etc/samba/smb.conf
 }
 
 if [[ -z $1 ]] || [[ ${1:0:1} == '-' ]] ; then
     createUser
     backupConfig
+    makeOptions
     exec /usr/sbin/smbd --no-process-group --log-stdout --foreground "$@"
     exec "$@"
 fi

--- a/samba.conf
+++ b/samba.conf
@@ -36,7 +36,7 @@ client ipc min protocol = default
 client min protocol     = CORE
 server min protocol     = SMB2
 
-[TimeMachine]
+[REPLACE_SHARENAME]
 browseable              = Yes
 comment                 = Apple TimeMachine Backup Target
 inherit acls            = Yes

--- a/template_quota
+++ b/template_quota
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>GlobalQuota</key>
+    <integer>REPLACE_TM_SIZE</integer>
+  </dict>
+</plist>

--- a/timemachine.service
+++ b/timemachine.service
@@ -9,7 +9,7 @@
 	</service>
 	<service>
 		<type>_smb._tcp</type>
-		<port>445</port>
+		<port>10445</port>
 	</service>
 	<service>
 		<type>_device-info._tcp</type>


### PR DESCRIPTION
Hi there. I'm using your docker setup and I made a few tweaks. Mostly, I integrated some of the pieces I liked from https://github.com/willtho89/docker-samba-timemachine: namely, using alpine linux as a base, and adding a quota option. I also added an option to set the share name (for me "Data" seems to work best as it's what time machine seems to expect), with a new default. And I fixed a probably inconsequential bug in the entrypoint where you had ${ID} instead of ${GROUPID}.