### PR TITLE
fix smbd not starting due to invalid arguments

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -42,6 +42,6 @@ if [[ -z $1 ]] || [[ ${1:0:1} == '-' ]] ; then
     createUser
     backupConfig
     makeOptions
-    exec /usr/sbin/smbd --no-process-group --log-stdout --foreground "$@"
+    exec /usr/sbin/smbd --no-process-group --foreground "$@"
     exec "$@"
 fi


### PR DESCRIPTION
recent versions of smbd don't support '--log-stdout' argument anymore. this PR removes that option.