### PR TITLE
fix: parsing of container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ docker pull awlnx/samba-timemachine
 docker run -d -t \
     -v /backups/timemachine:/backups:z \
     -p 10445:445 \
-    --restart unless-stopped awlnx/samba-timemachine \
-    --name timemachine
+    --name timemachine \
+    --restart unless-stopped awlnx/samba-timemachine 
 ```
 
 Note that due to the use of port 10445 this container can be run along side a normal SAMBA service.


### PR DESCRIPTION
the --name was parsed as an arg to the entrypoint script leading to an error